### PR TITLE
Add support for CocoaPods bundle structure

### DIFF
--- a/Sources/JSErrorDomain.swift
+++ b/Sources/JSErrorDomain.swift
@@ -104,6 +104,7 @@ extension JSErrorDomain {
 
     /// A set of localized error strings.
     private enum LocalizedStrings: String {
+
         static let localizationContainer: Bundle = {
             if let bundle = Bundle(identifier: "fr.alexaubry.JavaScriptKit") {
                 return bundle

--- a/Sources/JSErrorDomain.swift
+++ b/Sources/JSErrorDomain.swift
@@ -104,9 +104,16 @@ extension JSErrorDomain {
 
     /// A set of localized error strings.
     private enum LocalizedStrings: String {
-
-        static var localizationContainer = Bundle(identifier: "fr.alexaubry.JavaScriptKit")!
-        static var localizationTableName = "Localizable"
+        static let localizationContainer: Bundle = {
+            if let bundle = Bundle(identifier: "fr.alexaubry.JavaScriptKit") {
+                return bundle
+            } else {
+                let frameworkBundle = Bundle(for: JavaScriptEncoder.self)
+                let url = frameworkBundle.url(forResource: "JavaScriptKit", withExtension: "bundle")!
+                return Bundle(url: url)!
+            }
+        }()
+        static let localizationTableName = "Localizable"
 
         case invalidReturnType = "JSErrorDomain.InvalidReturnType"
         case executionError = "JSErrorDomain.ExecutionError"

--- a/Sources/JSErrorDomain.swift
+++ b/Sources/JSErrorDomain.swift
@@ -105,6 +105,8 @@ extension JSErrorDomain {
     /// A set of localized error strings.
     private enum LocalizedStrings: String {
 
+        static let localizationTableName = "Localizable"
+
         static let localizationContainer: Bundle = {
             if let bundle = Bundle(identifier: "fr.alexaubry.JavaScriptKit") {
                 return bundle
@@ -114,7 +116,6 @@ extension JSErrorDomain {
                 return Bundle(url: url)!
             }
         }()
-        static let localizationTableName = "Localizable"
 
         case invalidReturnType = "JSErrorDomain.InvalidReturnType"
         case executionError = "JSErrorDomain.ExecutionError"


### PR DESCRIPTION
When using JavaScriptKit with CocoaPods, the localizable strings are not placed in the framework itself, but rather in a `JavaScriptKit.bundle` folder within the framework. For this change, we needed to update the `JSErrorDomain.LocalizedStrings.localizationContainer`.